### PR TITLE
fix(api): add global axios interceptor to inject jwt token

### DIFF
--- a/Frontend/src/services/apiContext/api.context.jsx
+++ b/Frontend/src/services/apiContext/api.context.jsx
@@ -5,6 +5,20 @@ import { mockProducts, mockUsers, mockSaleOrders } from "../../data/mockData";
 // Configuración de la URL base dinámica para Producción (Railway) o Local
 axios.defaults.baseURL = import.meta.env.VITE_API_URL || "";
 
+// Configuración de interceptor para enviar el token JWT automáticamente
+axios.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      config.headers["Authorization"] = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
 const APIContext = createContext();
 
 const cartValue = JSON.parse(localStorage.getItem("cart"));


### PR DESCRIPTION
- Implemented an axios request interceptor to automatically attach the Authorization Bearer token from localStorage to all outgoing requests.
- This resolves the issue where protected endpoints (like /api/User and /api/SaleOrder) were failing with 401 Unauthorized, causing the dashboard to show empty mock data.